### PR TITLE
modified def _report_dead_cam(m3u8_target)

### DIFF
--- a/stream_downloader.py
+++ b/stream_downloader.py
@@ -37,7 +37,7 @@ def _report_dead_cam(m3u8_target):
     Writes dead camera links to file to be removed 
     """
     with open("deadCams.txt", "r") as deadFile:
-        deadCamList = deadFile.readlines()
+        deadCamList = [line.rstrip('\n') for line in deadFile]
     with open("deadCams.txt", "a") as deadFile:
         if m3u8_target not in deadCamList:
             deadFile.write(m3u8_target)


### PR DESCRIPTION
I found that the original code
`deadCamList = deadCamFile.readlines()` saves each line with an empty line (\n)

For the reason, 
`if m3u8_target not in deadCamList:`
`deadFile.write(m3u8_target)`
This if statement is always true unless we put the parameter m3u8_target like (actual input) + '\n'

I believe the purpose of the if statement is for avoiding duplication.
However, Alex and I checked that the the code insults every inputs into m3u8sMaster.txt due to the problem I stated above.

Therefore, I modified the code
`deadCamList = deadCamFile.readlines()`
to
`deadCamList = [line.rstrip('\n') for line in deadFile]`
so that we can get only (actual input) from (actual input) + '\n'

Thank you.